### PR TITLE
keep compatibility with inner ssApps hosted in wallets

### DIFF
--- a/controllers/services/WalletRunner.js
+++ b/controllers/services/WalletRunner.js
@@ -63,6 +63,31 @@ function WalletRunner(options) {
       return {seed: this.seed};
     });
 
+    const removeSpinner = () => {
+      const spinner = document.querySelector('.loader-parent-container');
+      if (spinner) {
+        spinner.remove();
+      }
+      this.spinner.removeFromView();
+      iframe.hidden = false;
+    }
+
+    const keepSpinner = ()=>{
+      const fragment = iframe.contentWindow.document;
+      if (!fragment) {
+        return removeSpinner();
+      }
+
+      const root = fragment.querySelector('webc-app-root') || fragment.querySelector('psk-app-root');
+      if (!root) {
+        return removeSpinner();
+      }
+
+      root.componentOnReady().then(()=>{
+        removeSpinner();
+      });
+    }
+
 
     eventMiddleware.onStatus("completed", () => {
       if (iframe.hasAttribute("app-placeholder")) {
@@ -73,29 +98,9 @@ function WalletRunner(options) {
               .querySelectorAll("body > *:not(.loader-parent-container)")
               .forEach((node) => node.remove());
 
-          const removeSpinner = () => {
-            const spinner = document.querySelector('.loader-parent-container');
-            if (spinner) {
-              spinner.remove();
-            }
-            this.spinner.removeFromView();
-            iframe.hidden = false;
-          }
-
           iframe.hidden = true;
-          iframe.onload = async () => {
-            const fragment = iframe.contentWindow.document;
-            if (!fragment) {
-              return removeSpinner();
-            }
-
-            const root = fragment.querySelector('webc-app-root') || fragment.querySelector('psk-app-root');
-            if (!root) {
-              return removeSpinner();
-            }
-
-            await root.componentOnReady();
-            removeSpinner();
+          iframe.onload = () => {
+            keepSpinner();
           }
           document.body.prepend(iframe);
         } else {
@@ -139,6 +144,7 @@ function WalletRunner(options) {
          * remove all body elements that are related to loader UI except the iframe
          */
         try {
+          keepSpinner();
           document.querySelectorAll("body > *:not(iframe):not(.loader-parent-container)").forEach((node) => node.remove());
         } catch (e) {
           this.spinner.removeFromView();


### PR DESCRIPTION
For completion of the issue, each index.html of any ssapp will need to adapt their completion load code:

```
    <script>
        if (window.frameElement) {
            let iframeIdentity = window.frameElement.getAttribute('identity');

            //is just a hosted SSApp in a wallet
            let isSimpleSSApp = false;
            let iframeWindow = window.parent;
            if (!iframeIdentity) {
                isSimpleSSApp = true;

                //parent.top does not fit the case when the wallet is an iframe in another application
                let getWalletAppIframeWindow = function (parentWindow){

                    if (parentWindow.frameElement) {
                        if (parentWindow.frameElement.hasAttribute("identity")) {
                            iframeIdentity = parentWindow.frameElement.getAttribute("identity")
                            return parentWindow;
                        }
                    }

                    if(parentWindow === window.top){
                        console.log("No wallet environment found");
                        return;
                    }

                    return getWalletAppIframeWindow(parentWindow.parent);
                }

                iframeWindow = getWalletAppIframeWindow(iframeWindow);
            }

            if (iframeWindow) {
                iframeWindow.parent.document.dispatchEvent(new CustomEvent(iframeIdentity, {
                    detail: {
                        status: 'completed'
                    }
                }));
            }
        }
    </script>
```

I think is time to move this completion code in webcardinal ...